### PR TITLE
Fixing test-data generation\n

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -26,6 +26,8 @@
       <div class="header">
         <ul class="nav nav-pills pull-right">
           <li class="active"><a href="#">Home</a></li>
+          <li class="active"><a href="https://github.com/iamfruin/pecking-order" target="_blank">GitHub</a></li>
+          <li class="active"><a href="https://bramp.github.io/js-sequence-diagrams/" target="_blank">Syntax Help</a></li>
         </ul>
         <h3 class="text-muted">peck·ing or·der</h3>
       </div>
@@ -87,11 +89,14 @@
         //generate list of diagrams
         $.getJSON( "data/diagrams.json", function(data) {
           appendToList(diagrams, data);
-          diagrams.change();
+          selectStoredItem(diagrams);
+          
         });
 
          //eventhandler
         diagrams.change(function() {
+          var dropVal = $('option:selected', $(this)).text();
+            sessionStorage.setItem("SelectedDiagram", dropVal);
             drawDiagram();
         });
 
@@ -103,6 +108,13 @@
         download.click(function() {
           downloadDiagram();
         });
+
+        function selectStoredItem(element)
+        {
+          var selectedItem = sessionStorage.getItem("SelectedDiagram");
+          diagrams.find('option').filter(function() {return $(this).text() == selectedItem; }).attr('selected', 'selected');
+          diagrams.change();
+        }
 
         function drawDiagram() {
           // clear diagram

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -119,11 +119,13 @@ gulp.task('serve', ['styles', 'scripts', 'fonts', 'test-data'], () => {
   gulp.watch([
     'app/*.html',
     'app/data/*.txt',
+    'app/data/**/*.txt',
     'app/images/**/*',
     '.tmp/fonts/**/*'
   ]).on('change', reload);
 
-  gulp.watch('app/data/*.txt', ['data']);
+  gulp.watch('app/data/*.txt', ['test-data']);
+  gulp.watch('app/data/**/*.txt', ['test-data'])
   gulp.watch('app/styles/**/*.css', ['styles']);
   gulp.watch('app/scripts/**/*.js', ['scripts']);
   gulp.watch('app/fonts/**/*', ['fonts']);


### PR DESCRIPTION
1. Adding links to source and js-sequence-diagrams documentation
2. test-data is now run whenever a .txt file is changed in the development serve task
3. Persisting diagram selection during reload so you can edit it and not have to select it.
