### PR TITLE
Fixing load order for Diagrams.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,13 +118,11 @@ gulp.task('serve', ['styles', 'scripts', 'fonts', 'test-data'], () => {
 
   gulp.watch([
     'app/*.html',
-    'app/data/*.txt',
-    'app/data/**/*.txt',
+    'app/data/diagrams.json',
     'app/images/**/*',
     '.tmp/fonts/**/*'
   ]).on('change', reload);
 
-  gulp.watch('app/data/*.txt', ['test-data']);
   gulp.watch('app/data/**/*.txt', ['test-data'])
   gulp.watch('app/styles/**/*.css', ['styles']);
   gulp.watch('app/scripts/**/*.js', ['scripts']);


### PR DESCRIPTION
the gulp.watch("_.txt", ['test-data']) and gulp.watch(...,"app/data/__/_.txt").on('change',reload) were monitoring any .txt file.  so both watches were being fired at the same time.  Because of this the first watch could not always finish writing diagrams.json prior to the second reading it.

The diagrams.json file was getting loaded as it was being written by the test-data task
